### PR TITLE
Make FlushICache NOP for Nvidia Denver 1.0

### DIFF
--- a/src/arm/assembler-arm.cc
+++ b/src/arm/assembler-arm.cc
@@ -127,6 +127,11 @@ void CpuFeatures::ProbeImpl(bool cross_compile) {
   }
 
   if (FLAG_enable_32dregs && cpu.has_vfp3_d32()) supported_ |= 1u << VFP32DREGS;
+
+  if (cpu.implementer() == base::CPU::NVIDIA &&
+      cpu.variant() == base::CPU::NV_VIRIANT_DENVER &&
+      cpu.part() == base::CPU::NV_DENVER_V1)
+      supported_ |= 1u << COHERENT_CACHE;
 #endif
 
   DCHECK(!IsSupported(VFP3) || IsSupported(ARMv7));
@@ -188,14 +193,15 @@ void CpuFeatures::PrintTarget() {
 void CpuFeatures::PrintFeatures() {
   printf(
     "ARMv7=%d VFP3=%d VFP32DREGS=%d NEON=%d SUDIV=%d UNALIGNED_ACCESSES=%d "
-    "MOVW_MOVT_IMMEDIATE_LOADS=%d",
+    "MOVW_MOVT_IMMEDIATE_LOADS=%d COHERENT_CACHE=%d",
     CpuFeatures::IsSupported(ARMv7),
     CpuFeatures::IsSupported(VFP3),
     CpuFeatures::IsSupported(VFP32DREGS),
     CpuFeatures::IsSupported(NEON),
     CpuFeatures::IsSupported(SUDIV),
     CpuFeatures::IsSupported(UNALIGNED_ACCESSES),
-    CpuFeatures::IsSupported(MOVW_MOVT_IMMEDIATE_LOADS));
+    CpuFeatures::IsSupported(MOVW_MOVT_IMMEDIATE_LOADS),
+    CpuFeatures::IsSupported(COHERENT_CACHE));
 #ifdef __arm__
   bool eabi_hardfloat = base::OS::ArmUsingHardFloat();
 #elif USE_EABI_HARDFLOAT

--- a/src/arm/cpu-arm.cc
+++ b/src/arm/cpu-arm.cc
@@ -27,6 +27,8 @@ namespace internal {
 void CpuFeatures::FlushICache(void* start, size_t size) {
   if (size == 0) return;
 
+  if(CpuFeatures::IsSupported(COHERENT_CACHE)) return;
+
 #if defined(USE_SIMULATOR)
   // Not generating ARM instructions for C-code. This means that we are
   // building an ARM emulator based target.  We should notify the simulator

--- a/src/arm64/assembler-arm64.cc
+++ b/src/arm64/assembler-arm64.cc
@@ -44,8 +44,13 @@ namespace internal {
 // CpuFeatures implementation.
 
 void CpuFeatures::ProbeImpl(bool cross_compile) {
-  // AArch64 has no configuration options, no further probing is required.
   supported_ = 0;
+  // Probe for runtime features
+  base::CPU cpu;
+    if (cpu.implementer() == base::CPU::NVIDIA &&
+        cpu.variant() == base::CPU::NV_VIRIANT_DENVER &&
+        cpu.part() == base::CPU::NV_DENVER_V1)
+        supported_ |= 1u << COHERENT_CACHE;
 }
 
 

--- a/src/arm64/cpu-arm64.cc
+++ b/src/arm64/cpu-arm64.cc
@@ -43,6 +43,8 @@ class CacheLineSizes {
 void CpuFeatures::FlushICache(void* address, size_t length) {
   if (length == 0) return;
 
+  if(CpuFeatures::IsSupported(COHERENT_CACHE)) return;
+
 #ifdef USE_SIMULATOR
   // TODO(all): consider doing some cache simulation to ensure every address
   // run has been synced.

--- a/src/base/cpu.cc
+++ b/src/base/cpu.cc
@@ -299,6 +299,7 @@ CPU::CPU() : stepping_(0),
              type_(0),
              implementer_(0),
              architecture_(0),
+             variant_(0),
              part_(0),
              has_fpu_(false),
              has_cmov_(false),
@@ -389,6 +390,16 @@ CPU::CPU() : stepping_(0),
       implementer_ = 0;
     }
     delete[] implementer;
+  }
+
+  char* variant = cpu_info.ExtractField("CPU variant");
+  if (variant != NULL) {
+    char* end ;
+    variant_ = strtol(variant, &end, 0);
+    if (end == variant) {
+      variant_ = 0;
+    }
+    delete[] variant;
   }
 
   // Extract part number from the "CPU part" field.
@@ -541,6 +552,15 @@ CPU::CPU() : stepping_(0),
       implementer_ = 0;
     }
     delete[] implementer;
+  }
+  char* variant = cpu_info.ExtractField("CPU variant");
+  if (variant != NULL) {
+    char* end ;
+    variant_ = strtol(variant, &end, 0);
+    if (end == variant) {
+      variant_ = 0;
+    }
+    delete[] variant;
   }
 
   // Extract part number from the "CPU part" field.

--- a/src/base/cpu.h
+++ b/src/base/cpu.h
@@ -47,6 +47,8 @@ class CPU FINAL {
   static const int NVIDIA = 0x4e;
   static const int QUALCOMM = 0x51;
   int architecture() const { return architecture_; }
+  int variant() const { return variant_; }
+  static const int NV_VIRIANT_DENVER = 0x0;
   int part() const { return part_; }
   static const int ARM_CORTEX_A5 = 0xc05;
   static const int ARM_CORTEX_A7 = 0xc07;
@@ -54,6 +56,7 @@ class CPU FINAL {
   static const int ARM_CORTEX_A9 = 0xc09;
   static const int ARM_CORTEX_A12 = 0xc0c;
   static const int ARM_CORTEX_A15 = 0xc0f;
+  static const int NV_DENVER_V1 = 0x000;
 
   // General features
   bool has_fpu() const { return has_fpu_; }
@@ -90,6 +93,7 @@ class CPU FINAL {
   int type_;
   int implementer_;
   int architecture_;
+  int variant_;
   int part_;
   bool has_fpu_;
   bool has_cmov_;

--- a/src/globals.h
+++ b/src/globals.h
@@ -634,6 +634,7 @@ enum CpuFeature {
   MIPSr6,
   // ARM64
   ALWAYS_ALIGN_CSP,
+  COHERENT_CACHE,
   NUMBER_OF_CPU_FEATURES
 };
 


### PR DESCRIPTION
Cache is coherent in Denver hence make FlushICahce() as NOP
