### PR TITLE
workaround for cpuinfo changes in kernel, affects ARM platform detection addresses Issue 3112

### DIFF
--- a/src/base/cpu.cc
+++ b/src/base/cpu.cc
@@ -431,7 +431,20 @@ CPU::CPU() : stepping_(0),
       char* processor = cpu_info.ExtractField("Processor");
       if (HasListItem(processor, "(v6l)")) {
         architecture_ = 6;
-      }
+      } else {
+		// Due to changes in Linux kernel, there is a scenario
+		// where the "Processor" field no longer contains the
+		// processor architecture. The workaround for this issue
+		// is to inspect the "model name" field.
+		//
+	    // See: https://github.com/joyent/node/issues/8589
+		// See: https://code.google.com/p/v8/issues/detail?id=3112
+        delete[] processor;
+        processor = cpu_info.ExtractField("model name");
+        if (HasListItem(processor, "(v6l)")) {
+          architecture_ = 6;
+        }
+      }  
       delete[] processor;
     }
   }


### PR DESCRIPTION
workaround for cpuinfo changes in kernel, affects ARM platform detection addresses Issue 3112

See: https://github.com/iojs/io.js/issues/283
See: https://github.com/joyent/node/issues/7222
See: https://github.com/joyent/node/issues/8589
See: https://code.google.com/p/v8/issues/detail?id=3112