### PR TITLE
If FreeBSD is Linux then so is OpenBSD

### DIFF
--- a/build/landmine_utils.py
+++ b/build/landmine_utils.py
@@ -33,7 +33,7 @@ def IsWindows():
 
 @memoize()
 def IsLinux():
-  return sys.platform.startswith(('linux', 'freebsd'))
+  return sys.platform.startswith(('linux', 'freebsd', 'openbsd'))
 
 
 @memoize()


### PR DESCRIPTION
This makes landmine work on OpenBSD. I haven't detected any negative effects from
this, but I haven't used it extensively.