### PR TITLE
Stage 3 Proposal: Object.getOwnPropertyDescriptors

### DIFF
--- a/src/js/v8natives.js
+++ b/src/js/v8natives.js
@@ -777,6 +777,18 @@ function ObjectGetOwnPropertyDescriptor(obj, p) {
   return %GetOwnProperty(obj, p);
 }
 
+// ES proposal https://github.com/tc39/proposal-object-getownpropertydescriptors
+function ObjectGetOwnPropertyDescriptors(obj) {
+  if (!IS_RECEIVER(obj)) {
+    throw MakeTypeError(kCalledOnNonObject, "Object.getOwnPropertyDescriptors");
+  }
+  var names = %GetOwnPropertyKeys(obj, PROPERTY_FILTER_NONE);
+  var descriptors = new GlobalObject();
+  for (var i = 0; i < names.length; i++) {
+    descriptors[names[i]] = %GetOwnProperty(obj, names[i]);
+  }
+  return descriptors;
+}
 
 // ES5 section 15.2.3.6.
 function ObjectDefineProperty(obj, p, attributes) {
@@ -878,6 +890,7 @@ utils.InstallFunctions(GlobalObject, DONT_ENUM, [
   "getPrototypeOf", ObjectGetPrototypeOf,
   "setPrototypeOf", ObjectSetPrototypeOf,
   "getOwnPropertyDescriptor", ObjectGetOwnPropertyDescriptor,
+  "getOwnPropertyDescriptors", ObjectGetOwnPropertyDescriptors,
   // getOwnPropertySymbols is added in symbol.js.
   "is", SameValue,  // ECMA-262, Edition 6, section 19.1.2.10
   // deliverChangeRecords, getNotifier, observe and unobserve are added


### PR DESCRIPTION
There's a [stage 3 proposal](https://github.com/tc39/proposal-object-getownpropertydescriptors#objectgetownpropertydescriptors-proposal-polyfill) waiting to be implemented in at least two browsers [in order to make it to stage 4](https://github.com/tc39/proposal-object-getownpropertydescriptors/issues/9).

Tests has been submitted to test262 by the champion ( @ljharb ) so the last bit would be to actually implement it in core.

These changes have been successfully tested already after a clean `make native` and double-verified manually within d8 console itself.

Thanks in advance for considering this PR or for clarifying what else is needed in order to integrate such proposal.

Best Regards