### PR TITLE
[platform] fix uninitialized variable

### DIFF
--- a/src/base/platform/time.cc
+++ b/src/base/platform/time.cc
@@ -609,7 +609,7 @@ TimeTicks TimeTicks::Now() {
 
 
 TimeTicks TimeTicks::HighResolutionNow() {
-  int64_t ticks;
+  int64_t ticks = 0;
 #if V8_OS_MACOSX
   static struct mach_timebase_info info;
   if (info.denom == 0) {


### PR DESCRIPTION
On line number `628` of [time.cc](https://github.com/v8/v8/blob/master/src/base/platform/time.cc#L628), the variable `ticks` may be accessed without an initialized value.  And while the return value of `TimeTicks::HighResolutionNow` will never be zero, it's always good to initialize variables, because if we try to access a value before it gets assigned any actual (non-garbage) value, then it results in undefined behavior.