### PR TITLE
parser.cc - moved declaration and init of assignments iterator to for…

### DIFF
--- a/src/parsing/parser.cc
+++ b/src/parsing/parser.cc
@@ -3566,8 +3566,8 @@ void Parser::RewriteAsyncFunctionBody(ScopedPtrList<Statement>* body,
 void Parser::RewriteDestructuringAssignments() {
   const auto& assignments =
       function_state_->destructuring_assignments_to_rewrite();
-  auto it = assignments.rbegin();
-  for (; it != assignments.rend(); ++it) {
+
+  for (auto it = assignments.rbegin(); it != assignments.rend(); ++it) {
     // Rewrite list in reverse, so that nested assignment patterns are rewritten
     // correctly.
     RewritableExpression* to_rewrite = *it;


### PR DESCRIPTION
… init block

Variable it (assignments iterator) is declared and initialized before the for loop, making it not consistent with basic rules and the rest of the code. Also, its scope is greater than it needs to be.