### PR TITLE
[wasm-hints] Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/wasm-compilation-hints/wasm-objdump-compilation-hints.py
+++ b/tools/wasm-compilation-hints/wasm-objdump-compilation-hints.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be found
 # in the LICENSE file.
 
+from __future__ import print_function
 import argparse
 import io
 import sys
@@ -34,10 +35,10 @@ if __name__ == "__main__":
         section_name_bs = fin.read(section_name_length)
         if section_name_bs == "compilationHints":
           num_hints, bs = read_varuintN(fin)
-          print "Custom section compilationHints with", num_hints, "hints:"
+          print("Custom section compilationHints with", num_hints, "hints:")
           for i in range(num_hints):
             hint, bs = read_uint8(fin)
-            print i, hex(hint)
+            print(i, hex(hint))
         else:
           remaining_length = payload_length \
               - len(section_name_length_bs) \


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected n both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/v8/v8 on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./test/preparser/testcfg.py:69:5: F821 undefined name 'execfile'
    execfile(pathname, {"Test": Test, "Template": Template})
    ^
./tools/wasm-compilation-hints/wasm-objdump-compilation-hints.py:37:54: E999 SyntaxError: invalid syntax
          print "Custom section compilationHints with", num_hints, "hints:"
                                                     ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'execfile'
2
```
@frgossen-g
@bmsdave