### PR TITLE
[test] execfile() was removed in Python 3

### DIFF
--- a/test/preparser/testcfg.py
+++ b/test/preparser/testcfg.py
@@ -66,7 +66,8 @@ class TestSuite(testsuite.TestSuite):
           testsource = testsource.replace("$" + key, replacement[key]);
         Test(testname, testsource, expectation)
       return MkTest
-    execfile(pathname, {"Test": Test, "Template": Template})
+    with open(pathname) as in_file:
+      exec(in_file.read(), {"Test": Test, "Template": Template})
 
   def ListTests(self):
     result = []


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/builtins.html#removed-execfile

[flake8](http://flake8.pycqa.org) testing of https://github.com/v8/v8 on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./test/preparser/testcfg.py:69:5: F821 undefined name 'execfile'
    execfile(pathname, {"Test": Test, "Template": Template})
    ^
./tools/wasm-compilation-hints/wasm-objdump-compilation-hints.py:37:54: E999 SyntaxError: invalid syntax
          print "Custom section compilationHints with", num_hints, "hints:"
                                                     ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'execfile'
2
```
@rryk
@bmsdave