### PR TITLE
Fix build error on Solaris: conflicting madvise() declaration

### DIFF
--- a/src/base/platform/platform-posix.cc
+++ b/src/base/platform/platform-posix.cc
@@ -69,14 +69,6 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-#if defined(V8_OS_SOLARIS)
-#if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE > 2) || defined(__EXTENSIONS__)
-extern "C" int madvise(caddr_t, size_t, int);
-#else
-extern int madvise(caddr_t, size_t, int);
-#endif
-#endif
-
 #ifndef MADV_FREE
 #define MADV_FREE MADV_DONTNEED
 #endif


### PR DESCRIPTION
Build on Solaris fails with following error:

```
./deps/v8/src/base/platform/platform-posix.cc:73:16: error: conflicting declara
tion of C function 'int madvise(caddr_t, std::size_t, int)'
 extern "C" int madvise(caddr_t, size_t, int);
                ^~~~~~~
In file included from ../deps/v8/src/base/platform/platform-posix.cc:20:0:
/usr/include/sys/mman.h:232:12: note: previous declaration 'int madvise(void*, s
td::size_t, int)'
 extern int madvise(void *, size_t, int);
            ^~~~~~~
```
There's no reason to re-declare madvise(3C) on any recent Solaris version, because the declaration is provided in sys/mman.h header depending on set of macros defined during compile time. Anyway the compiler / header chooses the right declaration from standard header file compatible with v8 as the build on Solaris works fine out-of-the-box when the private declaration in v8 is simply removed.

Snippet of man page of madvise(3C) follows, both header files already included by platform-posix.cc:

```
Standard C Library Functions                                       madvise(3C)

NAME
       madvise - provide advice to VM system

SYNOPSIS
       #include <sys/types.h>
       #include <sys/mman.h>

       int madvise(void *addr, size_t len, int advice);
```
https://docs.oracle.com/cd/E88353_01/html/E37843/madvise-3c.html