### PR TITLE
Define basestring in Python 3

### DIFF
--- a/tools/clusterfuzz/v8_foozzie_test.py
+++ b/tools/clusterfuzz/v8_foozzie_test.py
@@ -14,6 +14,11 @@ import v8_foozzie
 import v8_fuzz_config
 import v8_suppressions
 
+try:
+  basestring
+except NameError:
+  basestring = str
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 FOOZZIE = os.path.join(BASE_DIR, 'v8_foozzie.py')
 TEST_DATA = os.path.join(BASE_DIR, 'testdata')


### PR DESCRIPTION
The Python builtin `basestring` has been removed from all [currently supported versions of Python](https://devguide.python.org/#status-of-python-branches) so define `basestring` in Python 3 so that line 60 does not raise a NameError at runtime.  @bmsdave @targos Please submit upstream.