### PR TITLE
Undefined name: 'Error' use 'Exception' instead

### DIFF
--- a/tools/dev/update-compile-commands.py
+++ b/tools/dev/update-compile-commands.py
@@ -52,7 +52,7 @@ def PrepareBuildDir(arch, mode):
   build_ninja = os.path.join(build_dir, "build.ninja")
   if not os.path.exists(build_ninja):
     code = _Call("gn gen %s" % build_dir)
-    if code != 0: raise Error("gn gen failed")
+    if code != 0: raise Exception("gn gen failed")
   else:
     _Call("ninja -C %s build.ninja" % build_dir)
   return build_dir


### PR DESCRIPTION
@jakobkummerow https://docs.python.org/3/library/exceptions.html#Exception is the base class for most Python errors and `Error` is undefined in this context so NameError will be raised instead of the desired exception message.