### PR TITLE
Fix assert that is ALWAYS True

### DIFF
--- a/tools/clusterfuzz/js_fuzzer/tools/minimize.py
+++ b/tools/clusterfuzz/js_fuzzer/tools/minimize.py
@@ -23,7 +23,7 @@ OUT_PATH = os.path.join(BASE_PATH, 'out.js')
 FAILURES_JSON_PATH = os.path.join(
     BASE_PATH, 'workdir', 'output', 'failures.json')
 
-assert(len(sys.argv) > 1, 'Need to specify minimizer path.')
+assert len(sys.argv) > 1, 'Need to specify minimizer path.'
 minimizer_path = sys.argv[1]
 
 def getcmd(command):


### PR DESCRIPTION
@mi-ac `assert` is not a function in Python so the current assertion would _ALWAYS_ be True.