### PR TITLE
Remove extra class

### DIFF
--- a/include/v8.h
+++ b/include/v8.h
@@ -61,7 +61,6 @@ class ImplementationUtilities;
 class Int32;
 class Integer;
 class Isolate;
-class Isolate;
 class MicrotaskQueue;
 class Name;
 class Number;


### PR DESCRIPTION
Remove the `Isolate` class defined twice in the `v8` namespace in the header file.