### PR TITLE
src: fix typo in src/builtins/builtins-intl.cc comment

### DIFF
--- a/src/builtins/builtins-intl.cc
+++ b/src/builtins/builtins-intl.cc
@@ -246,7 +246,7 @@ Handle<JSFunction> CreateBoundFunction(Isolate* isolate,
 
 /**
  * Common code shared between DateTimeFormatConstructor and
- * NumberFormatConstrutor
+ * NumberFormatConstructor
  */
 template <class T>
 Object LegacyFormatConstructor(BuiltinArguments args, Isolate* isolate,


### PR DESCRIPTION
'NumberFormatConstructor' mispelled as 'NumberFormatConstrutor'