### PR TITLE
Let’s leave mistaken-pull-closer.yml in the wrong place

### DIFF
--- a/.github/mistaken-pull-closer.yml
+++ b/.github/mistaken-pull-closer.yml
@@ -1,4 +1,4 @@
-# `true` will close all PRs.
+# `true` will close all PRs...
 filters:
   - true
 


### PR DESCRIPTION
Does this PR autoclose itself?