### PR TITLE
Fix typo

### DIFF
--- a/src/api/api.cc
+++ b/src/api/api.cc
@@ -3957,7 +3957,7 @@ std::unique_ptr<v8::BackingStore> v8::BackingStore::Reallocate(
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
   LOG_API(i_isolate, ArrayBuffer, BackingStore_Reallocate);
   Utils::ApiCheck(byte_length <= i::JSArrayBuffer::kMaxByteLength,
-                  "v8::BackingStore::Reallocate", "byte_lenght is too large");
+                  "v8::BackingStore::Reallocate", "byte_length is too large");
   ENTER_V8_NO_SCRIPT_NO_EXCEPTION(i_isolate);
   i::BackingStore* i_backing_store =
       reinterpret_cast<i::BackingStore*>(backing_store.get());

--- a/test/mjsunit/wasm/compare-exchange-stress.js
+++ b/test/mjsunit/wasm/compare-exchange-stress.js
@@ -30,7 +30,7 @@ function makeWorkerCodeForOpcode(compareExchangeOpcode, size, functionName,
     }
     const kArgMemoryCell = 0; // target for atomic ops
     const kArgSequencePtr = 1; // address of sequence
-    const kArgSeqenceLength = 2; // lenght of sequence
+    const kArgSeqenceLength = 2; // length of sequence
     const kArgWorkerId = 3; // id of this worker
     const kArgBitMask = 4; // mask to extract worker id from value
     const kLocalCurrentOffset = 5; // current position in sequence in bytes

--- a/test/mjsunit/wasm/compare-exchange64-stress.js
+++ b/test/mjsunit/wasm/compare-exchange64-stress.js
@@ -33,7 +33,7 @@ function makeWorkerCodeForOpcode(compareExchangeOpcode, size, functionName,
     }
     const kArgMemoryCell = 0; // target for atomic ops
     const kArgSequencePtr = 1; // address of sequence
-    const kArgSeqenceLength = 2; // lenght of sequence
+    const kArgSeqenceLength = 2; // length of sequence
     const kArgWorkerId = 3; // id of this worker
     const kArgBitMask = 4; // mask to extract worker id from value
     const kLocalCurrentOffset = 5; // current position in sequence in bytes


### PR DESCRIPTION
* `src/api/api.cc` byte_lenght → **byte_length**
* `test/mjsunit/wasm/compare-exchange-stress.js` lenght → **length**
* `test/mjsunit/wasm/compare-exchange64-stress.js` lenght → **length**
