### PR TITLE
Removed "The open source browser from Google" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ V8 is Google's open source JavaScript engine.
 
 V8 implements ECMAScript as specified in ECMA-262.
 
-V8 is written in C++ and is used in Google Chrome, the web browser from Google.
+V8 is written in C++ and is used in Google Chrome, the *free* web browser from Google.
 
 V8 can run standalone, or can be embedded into any C++ application.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ V8 is Google's open source JavaScript engine.
 
 V8 implements ECMAScript as specified in ECMA-262.
 
-V8 is written in C++ and is used in Google Chrome, the open source
-browser from Google.
+V8 is written in C++ and is used in Google Chrome, the web browser from Google.
 
 V8 can run standalone, or can be embedded into any C++ application.
 


### PR DESCRIPTION
The README.md file in the V8 repo says: "V8 is written in C++ and is used in Google Chrome, the open source browser from Google.", which is not correct. Replaced "the open source browser from Google" to "the web browser from Google"