### PR TITLE
Fix undefined identifier libs

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -5677,6 +5677,8 @@ v8_component("v8_libbase") {
 
   deps = [ ":v8_config_headers" ]
 
+  libs = []
+
   data = []
 
   data_deps = []


### PR DESCRIPTION
Signed-off-by: McKnight22 <tao.wang.2261@gmail.com>

The undefined identifier "libs" would cause error when target_os = "android" and target_cpu = "riscv64" or "riscv".
