### PR TITLE
Update range-view.ts DOM text reinterpreted as HTML

### DIFF
--- a/tools/turbolizer/src/views/range-view.ts
+++ b/tools/turbolizer/src/views/range-view.ts
@@ -695,7 +695,7 @@ class StringConstructor {
                                         : num[num.length - i];
         str = `${addition} ${str}`;
       }
-      regEl.innerHTML = str;
+      regEl.innerText = str;
     } else if (!isVirtual) {
       const span = "".padEnd(C.FIXED_REGISTER_LABEL_WIDTH - registerName.length, "_");
       regEl.innerHTML = `HW - <span class='range-transparent'>${span}</span>${registerName}`;


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.