### PR TITLE
inspector/string-16.h: fix building with gcc on Apple

### DIFF
--- a/src/inspector/string-16.h
+++ b/src/inspector/string-16.h
@@ -163,7 +163,7 @@ String16 String16::concat(T... args) {
 
 }  // namespace v8_inspector
 
-#if !defined(__APPLE__) || defined(_LIBCPP_VERSION)
+#if !(defined(__APPLE__) && defined(__clang__)) || defined(_LIBCPP_VERSION)
 
 namespace std {
 template <>


### PR DESCRIPTION
The current condition is wrong when building with gcc on macOS (i.e. it just assumes clang without checking for it).