### PR TITLE
fix: correct typo "fallthru" to "fallthrough" in WebAssembly error message

### DIFF
--- a/src/wasm/function-body-decoder-impl.h
+++ b/src/wasm/function-body-decoder-impl.h
@@ -7696,7 +7696,7 @@ class WasmFullDecoder : public WasmDecoder<ValidationTag, decoding_mode> {
         merge_type == kBranchMerge     ? "branch"
         : merge_type == kReturnMerge   ? "return"
         : merge_type == kInitExprMerge ? "constant expression"
-                                       : "fallthru";
+                                       : "fallthrough";
     uint32_t arity = merge->arity;
     uint32_t actual = stack_.size() - control_.back().stack_depth;
     // Here we have to check for !unreachable(), because we need to typecheck as

--- a/test/message/fail/wasm-async-compile-fail.out
+++ b/test/message/fail/wasm-async-compile-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:9: CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/test/message/fail/wasm-async-instantiate-fail.out
+++ b/test/message/fail/wasm-async-instantiate-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:9: CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/test/message/fail/wasm-streaming-compile-fail.out
+++ b/test/message/fail/wasm-streaming-compile-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:11: CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:11: CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/test/message/fail/wasm-streaming-instantiate-fail.out
+++ b/test/message/fail/wasm-streaming-instantiate-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:11: CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:11: CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/test/message/fail/wasm-sync-compile-fail.out
+++ b/test/message/fail/wasm-sync-compile-fail.out
@@ -1,6 +1,6 @@
-*%(basename)s:9: CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 new WebAssembly.Module(builder.toBuffer());
 ^
-CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
     at *%(basename)s:9:1
 

--- a/test/mjsunit/wasm/async-compile.js
+++ b/test/mjsunit/wasm/async-compile.js
@@ -70,7 +70,7 @@ assertPromiseResult(async function badFunctionInTheMiddle() {
   await assertCompileError(
       buffer,
       'Compiling function #10:\"bad\" failed: ' +
-          'expected 1 elements on the stack for fallthru, found 0 @+94');
+          'expected 1 elements on the stack for fallthrough, found 0 @+94');
 }());
 
 assertPromiseResult(async function importWithoutCode() {

--- a/test/unittests/wasm/function-body-decoder-unittest.cc
+++ b/test/unittests/wasm/function-body-decoder-unittest.cc
@@ -3091,16 +3091,16 @@ TEST_F(FunctionBodyDecoderTest, MultiValBlock1) {
       {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1)), kExprI32Add});
   ExpectFailure(sigs.i_ii(), {WASM_BLOCK_X(sig0, WASM_NOP), kExprI32Add},
                 kAppendEnd,
-                "expected 2 elements on the stack for fallthru, found 0");
+                "expected 2 elements on the stack for fallthrough, found 0");
   ExpectFailure(
       sigs.i_ii(), {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0)), kExprI32Add},
-      kAppendEnd, "expected 2 elements on the stack for fallthru, found 1");
+      kAppendEnd, "expected 2 elements on the stack for fallthrough, found 1");
   ExpectFailure(sigs.i_ii(),
                 {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1),
                               WASM_LOCAL_GET(0)),
                  kExprI32Add},
                 kAppendEnd,
-                "expected 2 elements on the stack for fallthru, found 3");
+                "expected 2 elements on the stack for fallthrough, found 3");
   ExpectFailure(
       sigs.i_ii(),
       {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1)), kExprF32Add},
@@ -3996,7 +3996,7 @@ TEST_F(FunctionBodyDecoderTest, BrOnNonNull) {
 
     // br_on_non_null does not leave a value on the stack.
     ExpectFailure(&sig, {WASM_BR_ON_NON_NULL(0, WASM_LOCAL_GET(0))}, kAppendEnd,
-                  "expected 1 elements on the stack for fallthru, found 0");
+                  "expected 1 elements on the stack for fallthrough, found 0");
   }
 }
 
@@ -4030,7 +4030,7 @@ TEST_F(FunctionBodyDecoderTest, GCStruct) {
   ExpectFailure(
       &sig_r_v,
       {WASM_STRUCT_NEW(struct_type_index, WASM_I32V(0), WASM_I32V(1))},
-      kAppendEnd, "expected 1 elements on the stack for fallthru, found 2");
+      kAppendEnd, "expected 1 elements on the stack for fallthrough, found 2");
   // Mistyped arguments.
   ExpectFailure(&sig_v_r,
                 {WASM_STRUCT_NEW(struct_type_index, WASM_LOCAL_GET(0))},
@@ -4088,7 +4088,7 @@ TEST_F(FunctionBodyDecoderTest, GCStruct) {
                 {WASM_STRUCT_SET(struct_type_index, field_index,
                                  WASM_LOCAL_GET(0), WASM_I32V(0))},
                 kAppendEnd,
-                "expected 1 elements on the stack for fallthru, found 0");
+                "expected 1 elements on the stack for fallthrough, found 0");
   // Setting immutable field.
   ExpectFailure(sigs.v_v(),
                 {WASM_STRUCT_SET(
@@ -5981,7 +5981,7 @@ TEST_F(FunctionBodyDecoderTest, WasmSuspend) {
       sigs.v_v(), {WASM_SUSPEND(tag_i_i), WASM_DROP}, kAppendEnd,
       "not enough arguments on the stack for suspend (need 1, got 0)");
   ExpectFailure(sigs.v_v(), {WASM_I32V(42), WASM_SUSPEND(tag_i_i)}, kAppendEnd,
-                "expected 0 elements on the stack for fallthru, found 1");
+                "expected 0 elements on the stack for fallthrough, found 1");
   ExpectFailure(sigs.v_v(), {WASM_F64(42.0), WASM_SUSPEND(tag_i_i)}, kAppendEnd,
                 "suspend[0] expected type i32, found f64.const of type f64");
 }


### PR DESCRIPTION
This PR fixes a small typo in the WebAssembly error message.

The word "fallthru" was changed to "fallthrough" to align with standard English usage and improve clarity of error messages. The corrected spelling is more consistent with documentation and common usage:

https://en.wiktionary.org/wiki/fall-through#English

https://www.grammarly.com/blog/commonly-confused-words/through-thru/

Node.js repository received an [issue](https://github.com/nodejs/node/issues/58805) and a [PR](https://github.com/nodejs/node/pull/58819) resolving this, but since the string originates from V8, the change is being submitted here instead.

